### PR TITLE
cleanup the old GPIO flashing code so that it is cleaner and more reliable.

### DIFF
--- a/nodes_update_old.py
+++ b/nodes_update_old.py
@@ -1,7 +1,9 @@
+from numbers import Number
 from time import sleep
 import os
 import json
 from modules import clear_the_screen, Bcolors, logo_top, check_if_string_in_file
+import RPi.GPIO as GPIO
 
 """
 This is obsolete flashing protocol, left here only for some users.
@@ -36,35 +38,41 @@ def main():
     if preferred_rh_version == 'custom':
         firmware_version = 'stable'
 
-    nodes_number = data['nodes_number']
+    nodes_number = int(data['nodes_number'])
 
     # default to default pins. only update if they said so.
-    reset_1 = 12  # node 1   # default 12
-    reset_2 = 16  # node 2   # default 16
-    reset_3 = 20  # node 3   # default 20
-    reset_4 = 21  # node 4   # default 21
-    reset_5 = 6  # node 5   # default 6
-    reset_6 = 13  # node 6   # default 13
-    reset_7 = 19  # node 7   # default 19
-    reset_8 = 26  # node 8   # default 26
+    reset_pins=[
+        12  # node 1   # default 12
+        ,16  # node 2   # default 16
+        ,20  # node 3   # default 20
+        ,21  # node 4   # default 21
+        ,6  # node 5   # default 6
+        ,13  # node 6   # default 13
+        ,19  # node 7   # default 19
+        ,26  # node 8   # default 26
+    ]
     if pins_assignment == 'PCB' or pins_assignment == 'pcb':
-        reset_1 = 12  # node 1   # default 12
-        reset_2 = 16  # node 2   # default 16
-        reset_3 = 4  # node 3   # default 4
-        reset_4 = 21  # node 4   # default 21
-        reset_5 = 6  # node 5   # default 6
-        reset_6 = 13  # node 6   # default 13
-        reset_7 = 19  # node 7   # default 19
-        reset_8 = 26  # node 8   # default 26
+        reset_pins = [
+            12  # node 1   # default 12
+            ,16  # node 2   # default 16
+            ,4  # node 3   # default 4
+            ,21  # node 4   # default 21
+            ,6  # node 5   # default 6
+            ,13  # node 6   # default 13
+            ,19  # node 7   # default 19
+            ,26  # node 8   # default 26
+        ]
     if pins_assignment == 'custom':
-        reset_1 = 0  # node 1   # custom pin assignment
-        reset_2 = 0  # node 2   # custom pin assignment
-        reset_3 = 0  # node 3   # custom pin assignment
-        reset_4 = 0  # node 4   # custom pin assignment
-        reset_5 = 0  # node 5   # custom pin assignment
-        reset_6 = 0  # node 6   # custom pin assignment
-        reset_7 = 0  # node 7   # custom pin assignment
-        reset_8 = 0  # node 8   # custom pin assignment
+        reset_pins = [
+            0  # node 1   # custom pin assignment
+            , 0  # node 2   # custom pin assignment
+            , 0  # node 3   # custom pin assignment
+            , 0  # node 4   # custom pin assignment
+            , 0  # node 5   # custom pin assignment
+            , 0  # node 6   # custom pin assignment
+            , 0  # node 7   # custom pin assignment
+            , 0  # node 8   # custom pin assignment
+        ]
 
     if data['debug_mode']:
         linux_testing = True
@@ -77,167 +85,49 @@ def main():
         user = data['pi_user']
 
     if not linux_testing:
-        try:
-            import RPi.GPIO as GPIO
-        except ImportError:
-            import RPi.GPIO as GPIO
-            print("RPi.GPIO ImportError")
-
         GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)  # Use BCM pin numbering
-        GPIO.setup(reset_1, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(reset_2, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(reset_3, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(reset_4, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(reset_5, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(reset_6, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(reset_7, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(reset_8, GPIO.OUT, initial=GPIO.HIGH)
-
-        # def all_pins_low():
-        #     GPIO.output(reset_1, GPIO.LOW)
-        #     GPIO.output(reset_2, GPIO.LOW)
-        #     GPIO.output(reset_3, GPIO.LOW)
-        #     GPIO.output(reset_4, GPIO.LOW)
-        #     GPIO.output(reset_5, GPIO.LOW)
-        #     GPIO.output(reset_6, GPIO.LOW)
-        #     GPIO.output(reset_7, GPIO.LOW)
-        #     GPIO.output(reset_8, GPIO.LOW)
-        #     sleep(0.05)
+        GPIO.setup(reset_pins[0], GPIO.OUT, initial=GPIO.HIGH)
+        GPIO.setup(reset_pins[1], GPIO.OUT, initial=GPIO.HIGH)
+        GPIO.setup(reset_pins[2], GPIO.OUT, initial=GPIO.HIGH)
+        GPIO.setup(reset_pins[3], GPIO.OUT, initial=GPIO.HIGH)
+        GPIO.setup(reset_pins[4], GPIO.OUT, initial=GPIO.HIGH)
+        GPIO.setup(reset_pins[5], GPIO.OUT, initial=GPIO.HIGH)
+        GPIO.setup(reset_pins[6], GPIO.OUT, initial=GPIO.HIGH)
+        GPIO.setup(reset_pins[7], GPIO.OUT, initial=GPIO.HIGH)
 
         def all_pins_high():
-            GPIO.output(reset_1, GPIO.HIGH)
-            GPIO.output(reset_2, GPIO.HIGH)
-            GPIO.output(reset_3, GPIO.HIGH)
-            GPIO.output(reset_4, GPIO.HIGH)
-            GPIO.output(reset_5, GPIO.HIGH)
-            GPIO.output(reset_6, GPIO.HIGH)
-            GPIO.output(reset_7, GPIO.HIGH)
-            GPIO.output(reset_8, GPIO.HIGH)
+            GPIO.output(reset_pins[0], GPIO.HIGH)
+            GPIO.output(reset_pins[1], GPIO.HIGH)
+            GPIO.output(reset_pins[2], GPIO.HIGH)
+            GPIO.output(reset_pins[3], GPIO.HIGH)
+            GPIO.output(reset_pins[4], GPIO.HIGH)
+            GPIO.output(reset_pins[5], GPIO.HIGH)
+            GPIO.output(reset_pins[6], GPIO.HIGH)
+            GPIO.output(reset_pins[7], GPIO.HIGH)
             sleep(0.05)
 
-        # def all_pins_reset():
-        #     GPIO.output(reset_1, GPIO.LOW)
-        #     GPIO.output(reset_2, GPIO.LOW)
-        #     GPIO.output(reset_3, GPIO.LOW)
-        #     GPIO.output(reset_4, GPIO.LOW)
-        #     GPIO.output(reset_5, GPIO.LOW)
-        #     GPIO.output(reset_6, GPIO.LOW)
-        #     GPIO.output(reset_7, GPIO.LOW)
-        #     GPIO.output(reset_8, GPIO.LOW)
-        #     sleep(0.1)
-        #     GPIO.output(reset_1, GPIO.HIGH)
-        #     GPIO.output(reset_2, GPIO.HIGH)
-        #     GPIO.output(reset_3, GPIO.HIGH)
-        #     GPIO.output(reset_4, GPIO.HIGH)
-        #     GPIO.output(reset_5, GPIO.HIGH)
-        #     GPIO.output(reset_6, GPIO.HIGH)
-        #     GPIO.output(reset_7, GPIO.HIGH)
-        #     GPIO.output(reset_8, GPIO.HIGH)
-
-        def node_one_reset():
+        def flash_a_node(reset_pin, user, firmware_version, firmware_number, node_number):
             all_pins_high()
-            GPIO.output(reset_1, GPIO.LOW)
+            GPIO.output(reset_pin, GPIO.LOW)
             sleep(0.1)
-            GPIO.output(reset_1, GPIO.HIGH)
-
-        def node_two_reset():
-            all_pins_high()
-            GPIO.output(reset_2, GPIO.LOW)
-            sleep(0.1)
-            GPIO.output(reset_2, GPIO.HIGH)
-
-        def node_three_reset():
-            all_pins_high()
-            GPIO.output(reset_3, GPIO.LOW)
-            sleep(0.1)
-            GPIO.output(reset_3, GPIO.HIGH)
-
-        def node_four_reset():
-            all_pins_high()
-            GPIO.output(reset_4, GPIO.LOW)
-            sleep(0.1)
-            GPIO.output(reset_4, GPIO.HIGH)
-
-        def node_five_reset():
-            all_pins_high()
-            GPIO.output(reset_5, GPIO.LOW)
-            sleep(0.1)
-            GPIO.output(reset_5, GPIO.HIGH)
-
-        def node_six_reset():
-            all_pins_high()
-            GPIO.output(reset_6, GPIO.LOW)
-            sleep(0.1)
-            GPIO.output(reset_6, GPIO.HIGH)
-
-        def node_seven_reset():
-            all_pins_high()
-            GPIO.output(reset_7, GPIO.LOW)
-            sleep(0.1)
-            GPIO.output(reset_7, GPIO.HIGH)
-
-        def node_eight_reset():
-            all_pins_high()
-            GPIO.output(reset_8, GPIO.LOW)
-            sleep(0.1)
-            GPIO.output(reset_8, GPIO.HIGH)
+            GPIO.output(reset_pin, GPIO.HIGH)
+            os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
+                    flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_{firmware_number}.hex:i ")
+            print(f"\n\t\t\t\t{Bcolors.BOLD}Node {node_number} - flashed{Bcolors.ENDC}\n\n")
 
     if linux_testing:
-        # def all_pins_reset():
-        #     print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-        #     print("\n\t\t\t\t\t Linux - PC\n\n")
-        #     sleep(0.3)
-        #
-        # def all_pins_low():
-        #     print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-        #     print("\n\t\t\t\t\t Linux - PC\n\n")
-        #     sleep(0.3)
 
         def all_pins_high():
             print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
             print("\n\t\t\t\t\t Linux - PC\n\n")
             sleep(0.3)
 
-        def node_one_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
+        def flash_a_node(reset_pin, user, firmware_version, firmware_number, node_number):
+            print(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
+                    flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_{firmware_number}.hex:i ")
+            print(f"\n\t\t\t\t{Bcolors.BOLD}Node {node_number} - flashed{Bcolors.ENDC}\n\n")
 
-        def node_two_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
-
-        def node_three_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
-
-        def node_four_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
-
-        def node_five_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
-
-        def node_six_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
-
-        def node_seven_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
-
-        def node_eight_reset():
-            print(f"\n\n\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/X.hex")
-            print("\n\t\t\t\t\t Linux - PC\n\n")
-            sleep(0.3)
 
     def logo_update():
         print("""
@@ -252,175 +142,29 @@ def main():
                    blue=Bcolors.BLUE, yellow=Bcolors.YELLOW_S, red=Bcolors.RED_S, orange=Bcolors.ORANGE_S, s=10 * ' '))
 
     def flash_all_nodes():
-        node_one_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_1.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 1 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 1:
-            return
-        node_two_reset()
-        os.system("sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_2.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 2 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 2:
-            return
-        node_three_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_3.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 3 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 3:
-            return
-        node_four_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_4.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 4 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 4:
-            return
-        node_five_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_5.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 5 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 5:
-            return
-        node_six_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_6.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 6 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 6:
-            return
-        node_seven_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_7.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 7 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 7:
-            return
-        node_eight_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_8.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 8 - flashed{Bcolors.ENDC}\n\n")
-        if nodes_number == 8:
-            return
+        for node in range(1, nodes_number+1):
+            pin = reset_pins[node-1]
+            flash_a_node(pin, user, firmware_version, node, node)
 
     def flash_all_gnd():
-        node_one_reset()
+        for node in range(1, nodes_number+1):
+            pin = reset_pins[node-1]
+            flash_a_node(pin, user, firmware_version, 0, node)
+
+    def flash_a_blink(reset_pin, user, firmware_version, node_number):
+        all_pins_high()
+        GPIO.output(reset_pin, GPIO.LOW)
+        sleep(0.1)
+        GPIO.output(reset_pin, GPIO.HIGH)
         os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 1 - flashed{Bcolors.ENDC}\n\n")
+                flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
+        print(f"\n\t\t\t\t{Bcolors.BOLD}Node {node_number} - flashed{Bcolors.ENDC}\n\n")
         sleep(1)
-        if nodes_number == 1:
-            return
-        node_two_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 2 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 2:
-            return
-        node_three_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 3 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 3:
-            return
-        node_four_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 4 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 4:
-            return
-        node_five_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 5 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 5:
-            return
-        node_six_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 6 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 6:
-            return
-        node_seven_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 7 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 7:
-            return
-        node_eight_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 8 - flashed{Bcolors.ENDC}\n\n")
-        if nodes_number == 8:
-            return
 
     def flash_all_blink():
-        node_one_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 1 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 1:
-            return
-        node_two_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 2 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 2:
-            return
-        node_three_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 3 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 3:
-            return
-        node_four_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 4 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 4:
-            return
-        node_five_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 5 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 5:
-            return
-        node_six_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 6 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 6:
-            return
-        node_seven_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 7 - flashed{Bcolors.ENDC}\n\n")
-        sleep(1)
-        if nodes_number == 7:
-            return
-        node_eight_reset()
-        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-        print(f"\n\t\t\t\t{Bcolors.BOLD}Node 8 - flashed{Bcolors.ENDC}\n\n")
-        if nodes_number == 8:
-            return
+        for node in range(1, nodes_number+1):
+            pin = reset_pins[node-1]
+            flash_a_blink(pin, user, firmware_version, node)
 
     def flash_each_node():
         def node_x_menu(sel_node):
@@ -435,30 +179,13 @@ def main():
                 {Bcolors.ENDC}""")
                 selection = input()
                 if selection == '1':
-                    node_one_reset()
-                    if not linux_testing:
-                        os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-                        flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_"
-                                  + str(sel_node) + ".hex:i ")
-                    else:
-                        print(f"\t\t\t/home/{user}/RH-ota/firmware/obsolete/{firmware_version}\
-                        /node_{str(sel_node)}.hex:i ")
-                    print(f"{Bcolors.BOLD}\n\t Node {str(sel_node)} flashed\n{Bcolors.ENDC}")
-                    sleep(1.5)
+                    flash_a_node(reset_pins[sel_node - 1], user, firmware_version, sel_node, sel_node)
                     return
                 if selection == '2':
-                    node_one_reset()
-                    os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-                    flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/node_0.hex:i")
-                    print(f"{Bcolors.BOLD}\n\t Node {str(sel_node)} flashed\n{Bcolors.ENDC}")
-                    sleep(1.5)
+                    flash_a_node(reset_pins[sel_node - 1], user, firmware_version, 0, sel_node)
                     return
                 if selection == '3':
-                    node_one_reset()
-                    os.system(f"sudo avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U \
-                    flash:w:/home/{user}/RH-ota/firmware/obsolete/{firmware_version}/blink.hex:i ")
-                    print(f"{Bcolors.BOLD}\n\t Node {str(sel_node)} flashed\n{Bcolors.ENDC}")
-                    sleep(1.5)
+                    flash_a_blink(reset_pins[sel_node - 1], user, firmware_version, sel_node)
                     return
                 if selection == '4':
                     break
@@ -484,88 +211,29 @@ def main():
                 print(flash_node_menu)
                 selection = input("""
                         {bold}Which node do you want to program:{endc} """.format(bold=Bcolors.BOLD, endc=Bcolors.ENDC))
-                if selection == '1':
+                if selection.isnumeric() and 1 <= int(selection) <= 8:
                     node_x_menu(int(selection))
-                if selection == '2':
-                    node_x_menu(int(selection))
-                if selection == '3':
-                    node_x_menu(int(selection))
-                if selection == '4':
-                    node_x_menu(int(selection))
-                if selection == '5':
-                    node_x_menu(int(selection))
-                if selection == '6':
-                    node_x_menu(int(selection))
-                if selection == '7':
-                    node_x_menu(int(selection))
-                if selection == '8':
-                    node_x_menu(int(selection))
-                if selection == 'e':
+                elif selection == 'e':
                     break
-                else:
-                    continue
-
         node_menu()
 
     def gpio_state():
         clear_the_screen()
         logo_top(linux_testing)
         print("\n\n\n")
-        os.system(f"echo {reset_1} > /sys/class/GPIO/unexport")
-        os.system(f"echo {reset_2} > /sys/class/GPIO/unexport")
-        os.system(f"echo {reset_3} > /sys/class/GPIO/unexport")
-        os.system(f"echo {reset_4} > /sys/class/GPIO/unexport")
-        os.system(f"echo {reset_5} > /sys/class/GPIO/unexport")
-        os.system(f"echo {reset_6} > /sys/class/GPIO/unexport")
-        os.system(f"echo {reset_7} > /sys/class/GPIO/unexport")
-        os.system(f"echo {reset_8} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[0]} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[1]} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[2]} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[3]} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[4]} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[5]} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[6]} > /sys/class/GPIO/unexport")
+        os.system(f"echo {reset_pins[7]} > /sys/class/GPIO/unexport")
         os.system("echo 19 > /sys/class/GPIO/unexport")
         os.system("echo 20 > /sys/class/GPIO/unexport")
         os.system("echo 21 > /sys/class/GPIO/unexport")
         print("\n\n        DONE\n\n")
         sleep(0.3)
-
-    # def connectionTest():
-    # nodeOneReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 1:
-    # return
-    # nodeTwoReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 2:
-    # return
-    # nodeThreeReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 3:
-    # return
-    # nodeFourReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 4:
-    # return
-    # nodeFiveReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 5:
-    # return
-    # nodeSixReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 6:
-    # return
-    # nodeSevenReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 7:
-    # return
-    # nodeEightReset()
-    # os.system("sudo avrdude -c arduino -p m328p -v")
-    # sleep(2)
-    # if nodes_number == 8:
-    # return
 
     def nodes_update():
         while True:
@@ -611,8 +279,8 @@ def main():
                 break
             else:
                 continue
-
     nodes_update()
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 no matter what it was trying to flash all 8 nodes because

node_number was “4” instead of 4

tested flashing blink, flashing specific, flashing ground.