### PR TITLE
adding a press enter to continue after all nodes flashed using i2c.

### DIFF
--- a/conf_wizard_ota.py
+++ b/conf_wizard_ota.py
@@ -152,6 +152,9 @@ Are you using older, non-i2c hardware flashing mod?
                 print("\ntoo big fingers :( wrong command. try again! :)")
         if selection == 'y' or selection == 'yes':
             write_json(config, f"{home_dir}/RH-ota/updater-config.json")
+            #Once we write out the json config we should re-load it just
+            #to ensure consistency.
+            config = load_config()
             print("Configuration saved.\n")
             sleep(0.5)
             conf_now_flag = 0

--- a/nodes_flash.py
+++ b/nodes_flash.py
@@ -57,8 +57,9 @@ def flash_firmware(config):
 def flash_firmware_onto_all_nodes(config):  # nodes have to be 'auto-numbered'
     nodes_num = config.nodes_number
     odd_number = odd_number_of_nodes_check(config)
+    addresses = nodes_addresses()
     for i in range(0, nodes_num):
-        addr = nodes_addresses()[i]
+        addr = addresses[i]
         print(f"\n\t\t\t{Bcolors.BOLD}Flashing node {i + 1} {Bcolors.ENDC}(reset with I2C address: {addr})\n")
         prepare_mate_node(addr) if not config.debug_mode else print("debug mode")
         print(f"avrdude -v -p atmega328p -c arduino -P /dev/ttyS0 -b 57600 -U "
@@ -70,6 +71,7 @@ def flash_firmware_onto_all_nodes(config):  # nodes have to be 'auto-numbered'
             break
     flash_firmware_onto_gpio_node(config) if odd_number else None
     logo_update(config)
+    input("\nPress ENTER to continue.")
     sleep(2)
 
 


### PR DESCRIPTION
Also fixed an initial config bug where user was getting set to racer because config.json was not being reloaded. 