### PR TITLE
Dave dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 1. Automatic configuring Access Point
      - Hotspot: Configure always-on hotspot using Pi's built in Wifi 
      - Auto-Hotspot: Automatically connect to known wifi if available, or become hotspot if no network is found. 
+        - explanation: https://www.raspberryconnect.com/projects/65-raspberrypi-hotspot-accesspoints/158-raspberry-pi-auto-wifi-hotspot-switch-direct-connection
 
 Helpful developer/back-end options:
 1. Installing avrdude

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 1. Wizard install/update of RotorHazard server software
      - Choose which version of RotorHazard to install
-     - Preserves exisiting rotorhazard config file.
+     - Preserves existing rotorhazard config file.
      - Backup of existing RH install.
      - Automatically performs much of the RotorHazard specific Pi setup steps
 
@@ -16,7 +16,8 @@
      - Requires some hardware modification to enable
 
 1. Automatic configuring Access Point
-     - Smart-hotspot: dynamically connect to existing hotspot or server is the hotspot 
+     - Hotspot: Configure always-on hotspot using Pi's built in Wifi 
+     - Auto-Hotspot: Automatically connect to known wifi if available, or become hotspot if no network is found. 
 
 Helpful developer/back-end options:
 1. Installing avrdude
@@ -26,7 +27,7 @@ Helpful developer/back-end options:
 1. Embedded logging feature with an option to upload log file to the cloud 
 <br/>
 
-If you want all hardware functionalities - visit: [Instructables page](https://www.instructables.com/id/RotorHazard-Updater/)
+If you want all hardware functionality - visit: [Instructables page](https://www.instructables.com/id/RotorHazard-Updater/)
 or check the [RotorHazard-Updater.pdf](/how_to/RotorHazard-Updater.pdf).
 
 You may also read [update notes](/docs/update-notes.txt) - new features are present.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 1. Automatic configuring Access Point
      - Hotspot: Configure always-on hotspot using Pi's built in Wifi 
+        - You lose the ability to connect to the internet using built in Wifi. 
      - Auto-Hotspot: Automatically connect to known wifi if available, or become hotspot if no network is found. 
+        - If your Pi has been configured to connect to WIFI, this option allows you to use that wifi when in range, and still create a hotspot when not in range.
         - explanation: https://www.raspberryconnect.com/projects/65-raspberrypi-hotspot-accesspoints/158-raspberry-pi-auto-wifi-hotspot-switch-direct-connection
 
 Helpful developer/back-end options:

--- a/modules.py
+++ b/modules.py
@@ -150,15 +150,6 @@ def load_config():
         config.user = config.debug_user
     else:
         config.user = config.pi_user
-
-    if config.RH_version == 'master':
-        config.server_version = 'master'
-    if config.RH_version == 'beta':
-        config.server_version = '2.1.0-beta.3'
-    if config.RH_version == 'stable':
-        config.server_version = '2.1.1'
-    if config.RH_version == 'custom':
-        config.server_version = 'X.X.X'
     # paste custom version number here if you want to declare it manually
     return config
 

--- a/rpi_update.py
+++ b/rpi_update.py
@@ -90,7 +90,7 @@ def end_installation(user):
             os.system("./scripts/server_start.sh")
 
 
-def installation(conf_allowed, linux_testing, user, server_version):
+def installation(conf_allowed, linux_testing, user, RH_version):
     ota_config = load_ota_config(user)
     os.system("sudo systemctl stop rotorhazard >/dev/null 2>&1 &") if not linux_testing else None
     clear_the_screen()
@@ -117,11 +117,24 @@ def installation(conf_allowed, linux_testing, user, server_version):
                     """.format(thumbs="👍👍👍  ", bold=Bcolors.BOLD_S,
                                endc=Bcolors.ENDC_S, green=Bcolors.GREEN_S)
 
+        #TODO I would like to move th tags out of being hard-coded here.
+        #Maybe get a list of tags and ask user to select from list
+        #or automatically figure out the newest non-beta tag?
+        if RH_version == 'master':
+            server_version = 'master'
+        elif RH_version == 'beta':
+            server_version = '2.1.0-beta.3'
+        elif RH_version == 'stable':
+            server_version = '2.1.1'
+        else:
+            server_version = RH_version
+
         os.system(f"./scripts/install_rh.sh {user} {server_version}")
         input("press Enter to continue.")
         os.system("sh. ./scripts/sys_conf.sh") if conf_allowed else None
         ota_config.rh_installation_done = True
         write_ota_config(ota_config, user)
+        clear_the_screen()
         print(installation_completed)
         end_installation(user)
 
@@ -247,10 +260,10 @@ def main_window(config):
                 print(already_installed_prompt)
                 selection = input()
                 if selection == 'u':
-                    update(config.debug_mode, config.user, config.server_version)
+                    update(config.debug_mode, config.user, config.RH_version)
                 if selection == 'i':
                     conf_allowed = False
-                    installation(conf_allowed, config.debug_mode, config.user, config.server_version)
+                    installation(conf_allowed, config.debug_mode, config.user, config.RH_version)
                 if selection == 'c':
                     confirm_valid_options = ['y', 'yes', 'n', 'no', 'abort', 'a']
                     while True:
@@ -261,7 +274,7 @@ def main_window(config):
                             print("\ntoo big fingers :( wrong command. try again! :)")
                     if confirm == 'y' or confirm == 'yes':
                         conf_allowed = True
-                        installation(conf_allowed, config.debug_mode, config.user, config.server_version)
+                        installation(conf_allowed, config.debug_mode, config.user, config.RH_version)
                     if confirm in ['n', 'no', 'abort', 'a']:
                         pass
                 if selection == 'a':
@@ -271,7 +284,7 @@ def main_window(config):
                     break
             else:
                 conf_allowed = True
-                installation(conf_allowed, config.debug_mode, config.user, config.server_version)
+                installation(conf_allowed, config.debug_mode, config.user, config.RH_version)
         if selection == 'u':
             update(config.debug_mode, config.user, config.RH_version)
         if selection == 'e':

--- a/scripts/install_rh.sh
+++ b/scripts/install_rh.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# $1 is linux user name
+# $2 is actual version of RotorHazard to get.
 
 sudo apt-get update && sudo apt-get upgrade -y
 sudo apt autoremove -y
@@ -7,17 +9,17 @@ sudo -H pip install cffi pillow
 cd /home/"${1}" || exit
 if [ -d "/home/${1}/RotorHazard" ]; then
   # Control will enter here if $DIRECTORY exists.
-  mv "/home/${1}/RotorHazard" "/home/${1}/RotorHazard_$(date +%Y%m%d)"
+  mv "/home/${1}/RotorHazard" "/home/${1}/RotorHazard_$(date +%Y%m%d%H%M)" || exit 1
 fi
 if [ -d "/home/${1}/RotorHazard-${2}" ]; then
   # Control will enter here if $DIRECTORY exists.
-  mv "/home/${1}/RotorHazard-${2}" "/home/${1}/RotorHazard_${2}_$(date +%Y%m%d)"
+  mv "/home/${1}/RotorHazard-${2}" "/home/${1}/RotorHazard_${2}_$(date +%Y%m%d%H%M)" || exit 1
 fi
 cd /home/"${1}" || exit
 wget https://codeload.github.com/RotorHazard/RotorHazard/zip/"${2}" -O temp.zip
 unzip temp.zip
 rm temp.zip
-mv /home/"${1}"/RotorHazard-"${2}" /home/"${1}"/RotorHazard
+mv /home/"${1}"/RotorHazard-"${2}" /home/"${1}"/RotorHazard || exit 1
 sudo -H pip install -r /home/"${1}"/RotorHazard/src/server/requirements.txt
 sudo chmod 777 -R /home/"${1}"/RotorHazard/src/server
 cd /home/"${1}" || exit

--- a/scripts/update_rh.sh
+++ b/scripts/update_rh.sh
@@ -5,15 +5,15 @@ sudo -H pip install pillow
 sudo apt-get install libjpeg-dev ntp -y
 sudo apt-get update && sudo apt-get upgrade -y
 sudo apt autoremove -y
-upgradeDate="$(date +%Y%m%d)"
+upgradeDate="$(date +%Y%m%d%H%M)"
 cd /home/"${1}" || exit
 if [ -d "/home/${1}/RotorHazard" ]; then
   # Control will enter here if $DIRECTORY exists.
-  mv "/home/${1}/RotorHazard" "/home/${1}/RotorHazard_${upgradeDate}"
+  mv "/home/${1}/RotorHazard" "/home/${1}/RotorHazard_${upgradeDate}" || exit 1
 fi
 if [ -d "/home/${1}/RotorHazard-${2}" ]; then
   # Control will enter here if $DIRECTORY exists.
-  mv "/home/${1}/RotorHazard-${2}" "/home/${1}/RotorHazard_${2}_${upgradeDate}"
+  mv "/home/${1}/RotorHazard-${2}" "/home/${1}/RotorHazard_${2}_${upgradeDate}" || exit 1
 fi
 sudo rm -r /home/"${1}"/temp.zip >/dev/null 2>&1           # just in case of weird sys config
 cd /home/"${1}" || exit


### PR DESCRIPTION
* Cleaned up conf_wizard_ota so that old, stale values do not stay in updater_conf.json
  * made a few things more pythonic.
* Added support for downloading a custom RotorHazard version (Tested on 2.1.0 beta 2 and 3)
* moved the version decision tree into rpi_update.py instead of being in load_config.
* cleaned up README
* cleaned up install_rh.sh  so that it errors out if it is unable to make the backup directory.
* made install_rh.sh use date down to the minute so that installing multiple times in one day does not blow up.
* made update_rh.sh use date down to the minute so that upgrading multiple times per day does not blow up.
