### PR TITLE
Master

### DIFF
--- a/conf_wizard_ota.py
+++ b/conf_wizard_ota.py
@@ -66,7 +66,7 @@ If you want to use value given as default, just hit 'Enter'.
             config.pi_user = pi_user_name
         while True:
             version = input(f"\nChoose RotorHazard version? \
-[{Bcolors.UNDERLINE}stable{Bcolors.ENDC} | beta | master ]\t\t\t").lower()
+[{Bcolors.UNDERLINE}stable{Bcolors.ENDC} | beta | master]\t\t\t").lower()
             if not version:
                 config.rh_version = 'stable'
                 print("defaulted to: 'stable'")

--- a/conf_wizard_ota.py
+++ b/conf_wizard_ota.py
@@ -191,10 +191,10 @@ Flashing itself is not possible in "sim" mode!\t\t\t\t""").lower()
             while True:
                 old_hardware_mod = input("""
 Are you using older, non-i2c hardware flashing mod? 
-(nodes reset pins connected to gpio pins) [ y/N | default: no ]\t\t""").lower()
+(nodes reset pins connected to gpio pins) [y/N | default: no]\t\t""").lower()
                 if not old_hardware_mod:
                     old_hardware_mod, config.old_hw_mod = False, False
-                    print("\ndefaulted to: no")
+                    print("defaulted to: no")
                     break
                 elif old_hardware_mod[0] == "y":
                     old_hardware_mod, config.old_hw_mod = True, True

--- a/docs/update-notes.txt
+++ b/docs/update-notes.txt
@@ -11,9 +11,10 @@
 2. FAQ section added - mostly focused on ISP programming issues for now
 3. I2C bus number selection added to a config file and a flashing protocol
 (useful when using Banana Pi type SBCs etc)
-4. More useful "show i2c devices" menu - with i2c bus number indication
+4. More useful "Show I2C devices" menu - with I2C bus number indication
 5. More verbose log output
 6. Basic Serial interface diagnostic tool added
+7. Better error handling in few circumstances
 
 232.25.3f
 1. Automatic conversion existing sensors libraries to python3 versions added

--- a/docs/update-notes.txt
+++ b/docs/update-notes.txt
@@ -5,6 +5,10 @@
         UPDATE NOTES:
         ^^^^^^^^^^^^
 
+232.25.3h
+1. Automatic prompt when newer version of RotorHazard is available
+(when OTA is up-to-date, checks only for stable releases)
+
 232.25.3g
 1. Automatically generated prompt when newer version of OTA is available
 (if internet connection is available)

--- a/docs/update-notes.txt
+++ b/docs/update-notes.txt
@@ -8,6 +8,7 @@
 232.25.3h
 1. Automatic prompt when newer version of RotorHazard is available
 (when OTA is up-to-date, checks only for stable releases)
+2. Beta RotorHazard "3.0.0-beta.1" support
 
 232.25.3g
 1. Automatically generated prompt when newer version of OTA is available

--- a/rpi_update.py
+++ b/rpi_update.py
@@ -51,7 +51,7 @@ def get_rotorhazard_server_version(config):
                     server_installed_flag = True
                     break
     else:
-        server_version_name = f'{Bcolors.YELLOW}{Bcolors.UNDERLINE}installation not found{Bcolors.ENDC}'
+        colored_server_version_name = f'{Bcolors.YELLOW}{Bcolors.UNDERLINE}installation not found{Bcolors.ENDC}'
         server_installed_flag = False
     return server_installed_flag, server_version_name, colored_server_version_name
 

--- a/rpi_update.py
+++ b/rpi_update.py
@@ -12,7 +12,6 @@ def check_preferred_rh_version(config):
         first_line = file.readline()
 
     no_dots_rh_version = first_line.split(".")[0].strip()
-
     converted_rh_version_name = no_dots_rh_version[0] + "." + no_dots_rh_version[1] + "." + no_dots_rh_version[2:]
 
     stable_release_name = str(converted_rh_version_name)  # stable rh target is being loaded from the version.txt file
@@ -256,7 +255,7 @@ def main_window(config):
         
         You can change those in configuration wizard in Main Menu.
         
-        Server installed right now: {server} {bold}
+        Server version currently installed: {server} {bold}
         
         RotorHazard configuration state: {config_soft}
             

--- a/rpi_update.py
+++ b/rpi_update.py
@@ -227,7 +227,8 @@ def update(config):
             print(f"\n\n\t{Bcolors.BOLD}Updating existing installation - please wait...{Bcolors.ENDC}\n\n")
             os.system(f"./scripts/update_rh.sh {config.user} {check_preferred_rh_version(config)[0]}")
             config_flag, config_soft = check_rotorhazard_config_status(config)
-            server_installed_flag, server_version_name, colored_server_version_name = get_rotorhazard_server_version(config)
+            server_installed_flag, server_version_name, colored_server_version_name = \
+                get_rotorhazard_server_version(config)
             os.system("sudo chmod -R 777 ~/RotorHazard")
             end_update(config, config_flag, server_installed_flag)
 

--- a/rpi_update.py
+++ b/rpi_update.py
@@ -8,8 +8,14 @@ from modules import clear_the_screen, Bcolors, triangle_image_show, internet_che
 
 
 def check_preferred_rh_version(config):
+    with open("version.txt", "r") as file:
+        first_line = file.readline()
 
-    stable_release_name = '2.3.2'  # declare last stable release name here
+    no_dots_rh_version = first_line.split(".")[0].strip()
+
+    converted_rh_version_name = no_dots_rh_version[0] + "." + no_dots_rh_version[1] + "." + no_dots_rh_version[2:]
+
+    stable_release_name = str(converted_rh_version_name)  # stable rh target is being loaded from the version.txt file
 
     beta_release_name = '2.3.0-beta.3'  # declare last beta release name here
 

--- a/rpi_update.py
+++ b/rpi_update.py
@@ -17,7 +17,7 @@ def check_preferred_rh_version(config):
 
     stable_release_name = str(converted_rh_version_name)  # stable rh target is being loaded from the version.txt file
 
-    beta_release_name = '2.3.0-beta.3'  # declare last beta release name here
+    beta_release_name = '3.0.0-beta.1'  # declare last beta release name here
 
     if config.rh_version == 'stable':
         server_version = stable_release_name

--- a/update.py
+++ b/update.py
@@ -30,15 +30,16 @@ def config_check():
 
 def attribute_error_handling():
     err_msg = """
+    AttributeError
 
-    Looks that your username entered in the wizard is probably wrong.
-    There may also be another json config file error present.
+    Looks that you may have some configuration mismatch. 
+    Check entered username and other parameters in config wizard.
 
     You may also try to re-open the ota software with './ota.sh' command.
 
     """
     print(err_msg)
-    input("\n\n\tHit Enter to continue and re-enter configuration wizard.")
+    input("\n\n\tHit Enter to continue and next check your configuration.")
     clear_the_screen()
 
 

--- a/update.py
+++ b/update.py
@@ -179,7 +179,7 @@ def ota_update_available_check(config):
 
 
 def rh_update_check(config):
-    update_prompt = f"{Bcolors.RED}(pending stable update){Bcolors.ENDC}"
+    update_prompt = f"{Bcolors.RED}-> pending stable update{Bcolors.ENDC}"
     # above is showed only when stable version is newer than current
     raw_installed_rh_server = installed_rh_version(config)[1]  # 3.0.0-dev2
     installed_rh_server = raw_installed_rh_server.split("-")[0]  # 3.0.0

--- a/update.py
+++ b/update.py
@@ -152,7 +152,7 @@ def ota_update_available_check(config):
     else:
         ota_update_available_flag = False
 
-    if ota_update_available_flag:
+    if ota_update_available_flag and config.beta_tester is False:  # don't show update prompt to beta-testers
         clear_the_screen()
         logo_top(config.debug_mode)
         print("""\n\n {bold}

--- a/update.py
+++ b/update.py
@@ -172,7 +172,7 @@ def ota_update_available_check(config):
         while True:
             selection = input()
             if selection == 'u':
-                self_updater(config)  # TODO check bad exiting from that loop after update
+                self_updater(config)
                 break
             elif selection == 's':
                 break
@@ -180,11 +180,12 @@ def ota_update_available_check(config):
 
 def rh_update_check(config):
     update_prompt = f"{Bcolors.RED}(pending stable update){Bcolors.ENDC}"
-    raw_installed_rh_server = installed_rh_version(config)[1]
-    installed_rh_server = raw_installed_rh_server.split("-")[0]
-    installed_rh_server_number = int(installed_rh_server.replace(".", ""))
-    server_installed_flag = installed_rh_version(config)[0]
-    newest_possible_rh_version = int(possible_rh_version(config)[1])
+    # above is showed only when stable version is newer than current
+    raw_installed_rh_server = installed_rh_version(config)[1]  # 3.0.0-dev2
+    installed_rh_server = raw_installed_rh_server.split("-")[0]  # 3.0.0
+    installed_rh_server_number = int(installed_rh_server.replace(".", ""))  # 300
+    server_installed_flag = installed_rh_version(config)[0]  # check if RH is installed
+    newest_possible_rh_version = int(possible_rh_version(config)[1])  # derived from OTA name 232.25.3h -> 232
     if installed_rh_server_number < newest_possible_rh_version and server_installed_flag is True:
         rh_update_available_flag = True
     else:

--- a/update.py
+++ b/update.py
@@ -6,8 +6,7 @@ from conf_wizard_net import conf_wizard_net
 from conf_wizard_ota import conf_ota
 from modules import clear_the_screen, Bcolors, logo_top, triangle_image_show, ota_asci_image_show, load_config, \
     load_ota_sys_markers, write_ota_sys_markers, get_ota_version
-from rpi_update import main_window as rpi_update, get_rotorhazard_server_version as installed_rh_version, \
-    check_preferred_rh_version as possible_rh_version
+from rpi_update import main_window as rpi_update, rh_update_check
 from nodes_flash import flashing_menu
 from nodes_update_old import nodes_update as old_flash_gpio
 
@@ -176,24 +175,6 @@ def ota_update_available_check(config):
                 break
             elif selection == 's':
                 break
-
-
-def rh_update_check(config):
-    update_prompt = f"{Bcolors.RED}-> pending stable update{Bcolors.ENDC}"
-    # above is showed only when stable version is newer than current
-    raw_installed_rh_server = installed_rh_version(config)[1]  # 3.0.0-dev2
-    installed_rh_server = raw_installed_rh_server.split("-")[0]  # 3.0.0
-    installed_rh_server_number = int(installed_rh_server.replace(".", ""))  # 300
-    server_installed_flag = installed_rh_version(config)[0]  # check if RH is installed
-    newest_possible_rh_version = int(possible_rh_version(config)[1])  # derived from OTA name 232.25.3h -> 232
-    if installed_rh_server_number < newest_possible_rh_version and server_installed_flag is True:
-        rh_update_available_flag = True
-    else:
-        rh_update_available_flag = False
-    if rh_update_available_flag:
-        return update_prompt
-    else:
-        return ''
 
 
 def welcome_screen(config):
@@ -494,10 +475,7 @@ def main_menu(config):
     while True:
         clear_the_screen()
         logo_top(config.debug_mode)
-        try:
-            rh_update_prompt = rh_update_check(config)
-        except ValueError:
-            rh_update_prompt = ''
+        rh_update_prompt = rh_update_check(config)
         conf_color = Bcolors.GREEN if config_check() is False else ''
         main_menu_content = """
 

--- a/update.py
+++ b/update.py
@@ -494,7 +494,10 @@ def main_menu(config):
     while True:
         clear_the_screen()
         logo_top(config.debug_mode)
-        rh_update_prompt = rh_update_check(config)
+        try:
+            rh_update_prompt = rh_update_check(config)
+        except ValueError:
+            rh_update_prompt = ''
         conf_color = Bcolors.GREEN if config_check() is False else ''
         main_menu_content = """
 

--- a/version.txt
+++ b/version.txt
@@ -12,3 +12,5 @@ Done this way so the user would know at a glance if he has to update OTA to inst
 Features and functions are described in files in /docs folder.
 
 # keep the version number in first line of this file
+# this file is important cause stable RotorHazard target is being generated from the first number in first line
+# in the rpi_update.py file - first function - KEEP IT THAT WAY!!!

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
-232.25.3g
+232.25.3h1
 
 Version of this program - it has nothing to do with the RH version.
 First number refers to last stable RH version that can be installed using particular release.

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
-232.25.3h2
+232.25.3h
 
 Version of this program - it has nothing to do with the RH version.
 First number refers to last stable RH version that can be installed using particular release.


### PR DESCRIPTION
232.25.3h
1. Automatic prompt when newer version of RotorHazard is available
(when OTA is up-to-date, checks only for stable releases)
2. Beta RotorHazard "3.0.0-beta.1" support