### PR TITLE
Supports RotorHazard 3.1.0 (stable release) installation

### DIFF
--- a/docs/update-notes.txt
+++ b/docs/update-notes.txt
@@ -177,7 +177,6 @@ Simpler main menu, server start moved to RH Manager
 2.3.0c
 Added automatic I2C devices detection
 
-
 2.3.0
 First release of "new OTA" - all benefits listed in README.md this time
 New firmware with API level 23 (when 'master' release of RH is selected)

--- a/docs/update-notes.txt
+++ b/docs/update-notes.txt
@@ -5,6 +5,9 @@
         UPDATE NOTES:
         ^^^^^^^^^^^^
 
+311.35.3j3
+1. Supports RotorHazard 3.1.1 (stable release) installation
+
 310.35.3j3
 1. Supports RotorHazard 3.1.0 (stable release) installation
 

--- a/version.txt
+++ b/version.txt
@@ -12,5 +12,5 @@ Done this way so the user would know at a glance if he has to update OTA to inst
 Features and functions are described in files in /docs folder.
 
 # keep the version number in first line of this file
-# this file is important cause stable RotorHazard target is being generated from the first number in first line
+# this file is important cause stable RotorHazard target is being deducted from the first number in first line
 # in the rpi_update.py file - first function - KEEP IT THAT WAY!!!

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
-310.35.3j3
+311.35.3j3
 
 Version of this program - it has nothing to do with the RH version.
 First number refers to last stable RH version that can be installed using particular release.


### PR DESCRIPTION
311.35.3j3
1. Supports RotorHazard 3.1.0 (stable release) installation